### PR TITLE
Fix

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -4,13 +4,14 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   pr_agent_job:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    name: Run pr agent on every pull request, respond to user comments
+    name: Run pr agent
     if: ${{ github.event.sender.type != 'Bot' }}
     steps:
       - name: PR Agent action step


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
このPRは、GitHub Actionsのワークフロー設定における小さな改善を行います。
- `permissions` セクションをジョブの定義の先頭に移動し、ワークフローの可読性を向上させました。
- ジョブの名前を簡潔にし、その目的をより明確にしました。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>GitHub Actions設定の改善とジョブ名の簡略化</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml
<li><code>permissions</code> セクションをジョブの定義の先頭に移動しました。<br> <li> ジョブの名前を「Run pr agent on every pull request, respond to user <br>comments」から「Run pr agent」に変更しました。


</details>
    

  </td>
  <td><a href="https://github.com/fussy113/fussy113.github.io/pull/32/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

