### PR TITLE
Fix Actions node version dynamic

### DIFF
--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -26,9 +26,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Corepack enable because yarn v4 is used
         run: corepack enable
+      - name: Get node version from volta
+        id: get-node-version
+        uses: keita-hino/get-node-version-from-volta@main
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ steps.get-node-version.outputs.nodeVersion }}
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
このPRはGitHub Actionsの設定を改善し、Node.jsのバージョン管理にVoltaを使用するように変更します。これにより、プロジェクトのNode.jsバージョンをより柔軟に管理できるようになります。
- Voltaを使用してNode.jsのバージョンを動的に取得する新しいステップを追加しました。
- `actions/setup-node`の`node-version`パラメータを、Voltaから取得したNode.jsのバージョンに設定するように変更しました。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>js-test.yml</strong><dd><code>GitHub ActionsのNode.jsバージョンをVoltaで動的に設定</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/js-test.yml
<li>Voltaを使用してNode.jsのバージョンを動的に取得するステップを追加<br> <li> <code>actions/setup-node</code>でのNode.jsのバージョン指定をVoltaから取得した値に変更


</details>
    

  </td>
  <td><a href="https://github.com/fussy113/fussy113.github.io/pull/34/files#diff-d161c2529e77377c11fa3def1cbf11dfbdf1511b640d949e6024d2954e1183dc">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

