### PR TITLE
Fix node setup action

### DIFF
--- a/.github/composite/initialize/action.yml
+++ b/.github/composite/initialize/action.yml
@@ -1,24 +1,18 @@
-name: "initialize"
-description: "Initialize action"
+name: 'initialize'
+description: 'Initialize action'
 
 outputs:
   node_modules_cache_hit:
-    description: "Whether the node_modules cache was hit"
+    description: 'Whether the node_modules cache was hit'
     value: ${{ steps.node_modules_cache_id.outputs.cache-hit }}
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - uses: actions/checkout@v4
-    - name: Get node version from volta
-      id: get-node-version
-      uses: keita-hino/get-node-version-from-volta@main
-    - name: Corepack enable because yarn v4 is used
-      shell: bash
-      run: corepack enable
     - uses: actions/setup-node@v4
       with:
-        node-version: ${{ steps.get-node-version.outputs.nodeVersion }}
+        node-version-file: 'package.json'
         cache: 'yarn'
     - name: cache node_modules
       id: node_modules_cache_id

--- a/.github/composite/initialize/action.yml
+++ b/.github/composite/initialize/action.yml
@@ -14,7 +14,7 @@ runs:
       with:
         node-version-file: 'package.json'
         cache: 'yarn'
-    - name: cache node_modules
+    - name: restore node_modules
       id: node_modules_cache_id
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Nodeのセットアッププロセスを簡素化しました。
- `volta`に依存するステップを削除し、`package.json`からNodeのバージョンを直接指定するように変更しました。
- `corepack enable`のステップを削除し、設定を簡素化しました。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Nodeのセットアップアクションの改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/composite/initialize/action.yml
<li><code>name</code>と<code>description</code>の値をダブルクォートからシングルクォートに変更しました。<br> <li> <code>volta</code>を使用してnodeのバージョンを取得するステップを削除しました。<br> <li> <code>corepack enable</code>のステップを削除しました。<br> <li> <br><code>actions/setup-node@v4</code>を使用して、<code>node-version</code>の代わりに<code>node-version-file</code>を指定するように変更しました。


</details>
    

  </td>
  <td><a href="https://github.com/fussy113/fussy113.github.io/pull/37/files#diff-1d35d83c377790446a57a9623d31f5dfa5377c731bcd777ed39ab0907d898cdb">+5/-11</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

